### PR TITLE
Switch to "html/template" and improve the package page

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -1,9 +1,11 @@
 [
-    {"Repo": "git://github.com/paultag/go-debian",
+    {"Repo": "https://github.com/paultag/go-debian.git",
      "Path": "/go/debian",
-     "Packages": ["control", "dependency", "version"]},
+     "Packages": ["control", "dependency", "version"],
+     "Url": "https://github.com/paultag/go-debian"},
 
-    {"Repo": "git://github.com/paultag/go-topsort",
+    {"Repo": "https://github.com/paultag/go-topsort.git",
      "Path": "/go/topsort",
-     "Packages": []}
+     "Packages": [],
+     "Url": "https://github.com/paultag/go-topsort"}
 ]

--- a/template.html
+++ b/template.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html><html>
+	<head>
+		<meta charset="utf-8">
+		<title>{{ .Path }}</title>
+		<meta name="go-import" content="{{ .Path }} git {{ .Repo }}">
+	</head>
+	<body>
+		<div>package: <code>{{ .Path }}</code></div>
+		<div>source: <a href="{{ .Url }}">{{ .Url }}</a></div>
+		<div>godocs:<ul>
+			<li><a href="https://godoc.org/{{ .Path }}">{{ .Path }}</a></li>{{range .Packages}}
+			<li><a href="https://godoc.org/{{ $.Path }}/{{ . }}">{{ $.Path }}/{{ . }}</a></li>{{end}}
+		</ul></div>
+	</body>
+</html>


### PR DESCRIPTION
This improves the look of each "package" page, especially with more useful information and links. :+1:

Also, this switches the Git clone URLs to "https" (see https://help.github.com/articles/which-remote-url-should-i-use/), and adds an explicit "URL" for each package so we can link to browsable source code.
